### PR TITLE
 fix: correct pre-existing test mocking issues

### DIFF
--- a/backend/tests/test_rpc_service.py
+++ b/backend/tests/test_rpc_service.py
@@ -83,9 +83,24 @@ class TestRpcService(unittest.TestCase):
         self.assertNotIn('feerate_sat_per_vb', result)
 
     def test_clamps_target_in_rpc_call(self):
-        with patch.object(self.rpc, '_rpc_call', return_value={"feerate": 0.0001}) as mock:
+        def mock_rpc(method, params):
+            if method == "estimatesmartfee":
+                return {"feerate": 0.0001}
+            if method == "getblockcount":
+                return 800000
+            if method == "getmempoolfeeratediagram":
+                return [{"fee": 0.001, "weight": 100000}]
+            if method == "getblockstats":
+                return {"height": params[0], "total_weight": 1000000}
+            return None
+
+        with patch.object(self.rpc, '_rpc_call', side_effect=mock_rpc) as mock:
             self.rpc.estimate_smart_fee(1, "unset", 2)
-            self.assertEqual(mock.call_args[0][1][0], 2)  # params[0] should be 2
+            # Find the estimatesmartfee call — health stats trigger extra RPC calls
+            estimatesmartfee_calls = [c for c in mock.call_args_list if c[0][0] == "estimatesmartfee"]
+            self.assertGreater(len(estimatesmartfee_calls), 0)
+            params = estimatesmartfee_calls[0][0][1]
+            self.assertEqual(params[0], 2)  # params[0] should be clamped to 2
 
     # --- get_single_block_stats cache safety --------------------------------
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -21,15 +21,18 @@ export interface MempoolDiagramResponse {
 }
 
 export class BitcoinCoreAPI {
-  private baseUrl: string = API_BASE_PATH;
+  private baseUrl: string;
 
-  constructor() {
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl ?? API_BASE_PATH;
     console.debug(`[API Service] Using relative proxy path: ${this.baseUrl}`);
   }
 
   private async fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
     const cleanPath = path.replace(/^\/+/, "").replace(/\/+$/, "");
-    const url = `${this.baseUrl}/${cleanPath}`;
+    const url = this.baseUrl.startsWith("http")
+      ? `${this.baseUrl.replace(/\/+$/, "")}/${cleanPath}`
+      : `${this.baseUrl}/${cleanPath}`;
     try {
       const response = await fetch(url, options);
       if (!response.ok) {


### PR DESCRIPTION
This PR fixes two unrelated test issues so the suite runs reliably without false failures.

### 1. Backend: `test_clamps_target_in_rpc_call` (RPC service)

**problem:** The test mocks `_rpc_call` with a single `return_value`. `estimate_smart_fee()` performs several RPC calls internally (`estimatesmartfee`, `getblockchaininfo`, `getblockcount`, `getmempoolfeeratediagram`, `getblockstats`). `mock.call_args` refers to the **last** call, not the `estimatesmartfee` call, so the assertion on the clamped target can raise or assert the wrong thing.

**Error observed:**

```
self = <test_rpc_service.TestRpcService testMethod=test_clamps_target_in_rpc_call>

    def test_clamps_target_in_rpc_call(self):
        with patch.object(self.rpc, '_rpc_call', return_value={"feerate": 0.0001}) as mock:
            self.rpc.estimate_smart_fee(1, "unset", 2)
>           self.assertEqual(mock.call_args[0][1][0], 2)  # params[0] should be 2
                             ^^^^^^^^^^^^^^^^^^^^^^^
E           IndexError: list index out of range

tests/test_rpc_service.py:88: IndexError
------------------------------------------------- Captured log call --------------------------------------------------
ERROR    rpc_service:rpc_service.py:204 Failed to include health stats: -1
============================================== short test summary info ===============================================
FAILED tests/test_rpc_service.py::TestRpcService::test_clamps_target_in_rpc_call - IndexError: list index out of range
```

---

### 2. Frontend: API constructor

**problem:** `BitcoinCoreAPI` did not accept a `baseUrl` argument. Tests pass `new BitcoinCoreAPI('http://test-api:5001')` so that `fetch` is mocked against that URL, but the argument was ignored and the client used `/api`, so assertions on the request URL fail and tests hit the real proxy instead of the mock.

**Error observed:**

```
 FAIL  src/services/api.test.ts
  BitcoinCoreAPI
    ✕ should fetch fee estimate (5 ms)
    ✕ should fetch block count with network info (1 ms)
    ✓ should handle fetch errors (2 ms)

  ● BitcoinCoreAPI › should fetch fee estimate

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "http://test-api:5001/fees/2/economical/2", undefined
    Received: "/api/fees/2/economical/2", undefined

    Number of calls: 1

      22 |
      23 |     const result = await api.getFeeEstimate(2, 'economical', 2);
    > 24 |     expect(fetchMock).toHaveBeenCalledWith('http://test-api:5001/fees/2/economical/2', undefined);
         |                       ^
      25 |     expect(result.feerate).toBe(0.0001);
      26 |   });
      27 |

      at Object.<anonymous> (src/services/api.test.ts:24:23)

  ● BitcoinCoreAPI › should fetch block count with network info

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "http://test-api:5001/blockcount", undefined
    Received: "/api/blockcount", undefined

    Number of calls: 1

      33 |
      34 |     const result = await api.getBlockCount();
    > 35 |     expect(fetchMock).toHaveBeenCalledWith('http://test-api:5001/blockcount', undefined);
         |                       ^
      36 |     expect(result.blockcount).toBe(800000);
      37 |     expect(result.chain_display).toBe('MAINNET');
      38 |   });

      at Object.<anonymous> (src/services/api.test.ts:35:23)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
```