### PR TITLE
rpc: pass options object as 3rd arg to estimatesmartfee

### DIFF
--- a/backend/src/services/rpc_client.py
+++ b/backend/src/services/rpc_client.py
@@ -136,7 +136,7 @@ class RpcClient:
         estimators and returns an ``estimator`` field naming the one chosen.
         """
         effective_target = _clamp_target(conf_target)
-        result = self.rpc_call("estimatesmartfee", [effective_target, mode, verbosity, block_policy_only])
+        result = self.rpc_call("estimatesmartfee", [effective_target, mode, {"verbosity": verbosity, "block_policy_only": block_policy_only}])
         if result and "feerate" in result:
             result["feerate_sat_per_vb"] = result["feerate"] * 100_000
         if result is not None:
@@ -149,7 +149,7 @@ class RpcClient:
         verbosity=2 includes mempool_health_statistics in the response, but only
         when block_policy_only=False.
         """
-        result = self.rpc_call("estimatesmartfee", [2, "unset", 2, False])
+        result = self.rpc_call("estimatesmartfee", [2, "unset", {"verbosity": 2}])
         if not result:
             return []
         raw_stats = result.get("mempool_health_statistics", [])

--- a/backend/tests/test_rpc_service.py
+++ b/backend/tests/test_rpc_service.py
@@ -127,7 +127,7 @@ class TestRpcClient(unittest.TestCase):
         with patch.object(self.client, 'rpc_call', side_effect=mock_rpc) as mock:
             self.client.estimate_smart_fee(2, "unset", 1)
             esf_calls = [c for c in mock.call_args_list if c[0][0] == "estimatesmartfee"]
-            self.assertEqual(esf_calls[0][0][1], [2, "unset", 1, False])
+            self.assertEqual(esf_calls[0][0][1][2]["verbosity"], 1)
 
     def test_block_policy_only_forwarded_to_rpc(self):
         def mock_rpc(method, params):
@@ -140,7 +140,7 @@ class TestRpcClient(unittest.TestCase):
         with patch.object(self.client, 'rpc_call', side_effect=mock_rpc) as mock:
             self.client.estimate_smart_fee(2, "unset", 2, block_policy_only=True)
             esf_calls = [c for c in mock.call_args_list if c[0][0] == "estimatesmartfee"]
-            self.assertEqual(esf_calls[0][0][1], [2, "unset", 2, True])
+            self.assertTrue(esf_calls[0][0][1][2]["block_policy_only"])
 
     def test_estimator_field_passed_through(self):
         def mock_rpc(method, params):
@@ -154,7 +154,7 @@ class TestRpcClient(unittest.TestCase):
             result = self.client.estimate_smart_fee(2, "unset", 2, block_policy_only=False)
         self.assertEqual(result['estimator'], 'mempool')
 
-    def test_mempool_health_uses_block_policy_only_false(self):
+    def test_mempool_health_uses_verbosity_2(self):
         captured = {}
 
         def mock_rpc(method, params):
@@ -167,7 +167,7 @@ class TestRpcClient(unittest.TestCase):
 
         with patch.object(self.client, 'rpc_call', side_effect=mock_rpc):
             self.client.get_mempool_health_statistics()
-        self.assertEqual(captured['params'][3], False)
+        self.assertEqual(captured['params'][2]["verbosity"], 2)
 
     # --- get_single_block_stats cache safety --------------------------------
 


### PR DESCRIPTION
The new API signature is: `estimatesmartfee` `conf_target` ("estimate_mode" {options}) where verbosity and block_policy_only are passed as a named options object at position 3, not as flat positional arguments.

Adapt backend api to these changes.